### PR TITLE
added line to calendar.html to ensure mobile compatibility will work

### DIFF
--- a/source/calendar/calendar.html
+++ b/source/calendar/calendar.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dev Log Calendar</title>
     <!-- Link to external CSS file for styling -->
     <link rel="stylesheet" href="calendar.css">


### PR DESCRIPTION
calendar mobile compatibilty wasn't working before. Was missing <meta name="viewport" content="width=device-width, initial-scale=1.0"> in calendar.html